### PR TITLE
Maven jib jenkins

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,11 +52,12 @@ node {
         }
     }
 
-    // adapted from:
-    // https://stackoverflow.com/questions/58562224/how-do-i-pass-jenkins-credentials-to-gradle
+    // see:
+    // https://stackoverflow.com/q/59661871/7773582
     def dockerImage
     withEnv(["DOCKER_CREDS=credentials('dockerregistry-login')"]) {
         stage('publish docker') {
+            sh "printenv"
             sh "echo \"user=${env.DOCKER_CREDS_USR}\"";
             sh "./mvnw -X -ntp jib:build"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,11 +52,11 @@ node {
         }
     }
 
-    // see:
-    // https://stackoverflow.com/q/59661871/7773582
     def dockerImage
-    withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USER')]) {
-        stage('publish docker') {
+    stage('publish docker') {
+        withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USER')]) {
+            sh "printenv"
+            sh "echo \"docker registry user = ${env.DOCKER_REGISTRY_USER}\""
             sh "./mvnw -X -ntp jib:build"
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ node {
     // see:
     // https://stackoverflow.com/q/59661871/7773582
     def dockerImage
-    withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USR')]) {
+    withDockerRegistry(credentialsId: 'dockerregistry-login', url: 'https://dockerregistry.eigenbaumarkt.com') {
         stage('publish docker') {
             sh "printenv"
             sh "echo \"user=${env.DOCKER_REGISTRY_USR}\"";

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ node {
     // see:
     // https://stackoverflow.com/q/59661871/7773582
     def dockerImage
-    withDockerRegistry(credentialsId: 'dockerregistry-login', url: 'https://dockerregistry.eigenbaumarkt.com') {
+    withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USER')]) {
         stage('publish docker') {
             sh "./mvnw -X -ntp jib:build"
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,6 +58,7 @@ node {
         withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USER')]) {
             sh "printenv"
             sh "echo \"docker registry user = ${env.DOCKER_REGISTRY_USER}\""
+            sh "ping -c 3 dockerregistry.eigenbaumarkt.com"
             sh "./mvnw -X -ntp jib:build"
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,11 +53,18 @@ node {
     }
 
     def dockerImage
+    def BUILD_DATE = sh(script: "echo `date +%s`", returnStdout: true).trim()
     stage('publish docker') {
         withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USER')]) {
             sh "printenv"
             sh "echo \"docker registry user = ${env.DOCKER_REGISTRY_USER}\""
-            sh "./mvnw -X -ntp jib:build"
+            sh '''
+                ./mvnw -X -ntp jib:build
+                -Dimage=dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news:$BUILD_DATE
+                -Dimage=dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news:latest
+                -Djib.to.auth.username=${env.DOCKER_REGISTRY_USER}
+                -Djib.to.auth.password=${env.DOCKER_REGISTRY_PWD}
+                '''
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,6 +55,7 @@ node {
     def dockerImage
     stage('publish docker') {
         withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USER')]) {
+            sh "ping -c 3 dockerregistry.eigenbaumarkt.com"
             sh "./mvnw -ntp jib:build"        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,11 +5,6 @@ node {
         checkout scm
     }
 
-    environment {
-        DOCKER_REGISTRY = 'https://jenkins.eigenbaumarkt.com'
-        DOCKER_CREDS = credentials( 'dockerregistry-login' )
-    }
-
     docker.image('jhipster/jhipster:v6.6.0').inside('-u jhipster -e MAVEN_OPTS="-Duser.home=./"') {
         stage('check java') {
             sh "java -version"
@@ -60,7 +55,9 @@ node {
     // adapted from:
     // https://stackoverflow.com/questions/58562224/how-do-i-pass-jenkins-credentials-to-gradle
     def dockerImage
-    stage('publish docker') {
-        sh "./mvnw -ntp jib:build"
+    withEnv(["DOCKER_CREDS=credentials('dockerregistry-login')"]) {
+        stage('publish docker') {
+            sh "./mvnw -ntp jib:build"
+        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,7 @@ node {
     // see:
     // https://stackoverflow.com/q/59661871/7773582
     def dockerImage
-    withEnv(["DOCKER_CREDS=credentials('dockerregistry-login')"]) {
+    withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USR')]) {
         stage('publish docker') {
             sh "printenv"
             sh "echo \"user=${env.DOCKER_CREDS_USR}\"";

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,8 +58,11 @@ node {
         withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USER')]) {
             sh "printenv"
             sh "echo \"docker registry user = ${env.DOCKER_REGISTRY_USER}\""
-            sh "ping -c 3 dockerregistry.eigenbaumarkt.com"
+            sh "echo \"213.133.103.43 dockerregistry.eigenbaumarkt.com\" >> /etc/hosts"
+            sh "ping -c 3 https://dockerregistry.eigenbaumarkt.com"
             sh "./mvnw -X -ntp jib:build"
+            sh "sed -i '\$ d' /etc/hosts"
+            sh "ping -c 3 https://dockerregistry.eigenbaumarkt.com"
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ node {
     withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USR')]) {
         stage('publish docker') {
             sh "printenv"
-            sh "echo \"user=${env.DOCKER_CREDS_USR}\"";
+            sh "echo \"user=${env.DOCKER_REGISTRY_USR}\"";
             sh "./mvnw -X -ntp jib:build"
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -5,6 +5,11 @@ node {
         checkout scm
     }
 
+    environment {
+        DOCKER_REGISTRY = 'https://jenkins.eigenbaumarkt.com'
+        DOCKER_CREDS = credentials( 'dockerregistry-login' )
+    }
+
     docker.image('jhipster/jhipster:v6.6.0').inside('-u jhipster -e MAVEN_OPTS="-Duser.home=./"') {
         stage('check java') {
             sh "java -version"
@@ -29,7 +34,7 @@ node {
         stage('backend tests') {
             try {
                 sh "./mvnw -ntp verify"
-            } catch(err) {
+            } catch (err) {
                 throw err
             } finally {
                 junit '**/target/test-results/**/TEST-*.xml'
@@ -39,7 +44,7 @@ node {
         stage('frontend tests') {
             try {
                 sh "./mvnw -ntp com.github.eirslett:frontend-maven-plugin:npm -Dfrontend.npm.arguments='run test'"
-            } catch(err) {
+            } catch (err) {
                 throw err
             } finally {
                 junit '**/target/test-results/**/TEST-*.xml'
@@ -52,10 +57,10 @@ node {
         }
     }
 
+    // adapted from:
+    // https://stackoverflow.com/questions/58562224/how-do-i-pass-jenkins-credentials-to-gradle
     def dockerImage
     stage('publish docker') {
-        // A pre-requisite to this step is to setup authentication to the docker registry
-        // https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#authentication-methods
         sh "./mvnw -ntp jib:build"
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,8 +57,6 @@ node {
     def dockerImage
     withDockerRegistry(credentialsId: 'dockerregistry-login', url: 'https://dockerregistry.eigenbaumarkt.com') {
         stage('publish docker') {
-            sh "printenv"
-            sh "echo \"user=${env.DOCKER_REGISTRY_USR}\"";
             sh "./mvnw -X -ntp jib:build"
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,6 +57,7 @@ node {
     def dockerImage
     withEnv(["DOCKER_CREDS=credentials('dockerregistry-login')"]) {
         stage('publish docker') {
+            echo "user=$DOCKER_CREDS_USR pass=$DOCKER_CREDS_PSW";
             sh "./mvnw -X -ntp jib:build"
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,13 +58,8 @@ node {
         withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USER')]) {
             sh "printenv"
             sh "echo \"docker registry user = ${env.DOCKER_REGISTRY_USER}\""
-            sh '''
-                ./mvnw -X -ntp jib:build
-                -Dimage=dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news:$BUILD_DATE
-                -Dimage=dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news:latest
-                -Djib.to.auth.username=${env.DOCKER_REGISTRY_USER}
-                -Djib.to.auth.password=${env.DOCKER_REGISTRY_PWD}
-                '''
+            sh "./mvnw -X -ntp jib:build -Dimage=dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news:$BUILD_DATE -Dimage=dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news:latest -Djib.to.auth.username=${env.DOCKER_REGISTRY_USER} -Djib.to.auth.password=${env.DOCKER_REGISTRY_PWD}"
+
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,11 +58,7 @@ node {
         withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USER')]) {
             sh "printenv"
             sh "echo \"docker registry user = ${env.DOCKER_REGISTRY_USER}\""
-            sh "echo \"213.133.103.43 dockerregistry.eigenbaumarkt.com\" >> /etc/hosts"
             sh "ping -c 3 https://dockerregistry.eigenbaumarkt.com"
-            sh "./mvnw -X -ntp jib:build"
-            sh "sed -i '\$ d' /etc/hosts"
-            sh "ping -c 3 https://dockerregistry.eigenbaumarkt.com"
-        }
+            sh "./mvnw -X -ntp jib:build"        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ node {
     def dockerImage
     withEnv(["DOCKER_CREDS=credentials('dockerregistry-login')"]) {
         stage('publish docker') {
-            sh "./mvnw -ntp jib:build"
+            sh "./mvnw -X -ntp jib:build"
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ node {
         withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USER')]) {
             sh "printenv"
             sh "echo \"docker registry user = ${env.DOCKER_REGISTRY_USER}\""
-            sh "./mvnw -X -ntp jib:build -Dimage=dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news:$BUILD_DATE -Dimage=dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news:latest -Djib.to.auth.username=${env.DOCKER_REGISTRY_USER} -Djib.to.auth.password=${env.DOCKER_REGISTRY_PWD}"
+            sh "./mvnw -X -ntp jib:build -Dimage=dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news:$BUILD_DATE -Dimage=dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news:latest"
 
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -56,9 +56,6 @@ node {
     def BUILD_DATE = sh(script: "echo `date +%s`", returnStdout: true).trim()
     stage('publish docker') {
         withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USER')]) {
-            sh "printenv"
-            sh "echo \"docker registry user = ${env.DOCKER_REGISTRY_USER}\""
-            sh "ping -c 3 dockerregistry.eigenbaumarkt.com"
-            sh "./mvnw -X -ntp jib:build"        }
+            sh "./mvnw -ntp jib:build"        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,8 +58,7 @@ node {
         withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USER')]) {
             sh "printenv"
             sh "echo \"docker registry user = ${env.DOCKER_REGISTRY_USER}\""
-            sh "./mvnw -X -ntp jib:build -Dimage=dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news:$BUILD_DATE -Dimage=dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news:latest"
-
+            sh "./mvnw -X -ntp jib:build"
         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ node {
     def dockerImage
     withEnv(["DOCKER_CREDS=credentials('dockerregistry-login')"]) {
         stage('publish docker') {
-            echo "user=$DOCKER_CREDS_USR pass=$DOCKER_CREDS_PSW";
+            sh "echo \"user=$DOCKER_CREDS_USR pass=$DOCKER_CREDS_PSW\"";
             sh "./mvnw -X -ntp jib:build"
         }
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ node {
         withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USER')]) {
             sh "printenv"
             sh "echo \"docker registry user = ${env.DOCKER_REGISTRY_USER}\""
-            sh "ping -c 3 https://dockerregistry.eigenbaumarkt.com"
+            sh "ping -c 3 dockerregistry.eigenbaumarkt.com"
             sh "./mvnw -X -ntp jib:build"        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -53,7 +53,6 @@ node {
     }
 
     def dockerImage
-    def BUILD_DATE = sh(script: "echo `date +%s`", returnStdout: true).trim()
     stage('publish docker') {
         withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USER')]) {
             sh "./mvnw -ntp jib:build"        }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -55,7 +55,6 @@ node {
     def dockerImage
     stage('publish docker') {
         withCredentials([usernamePassword(credentialsId: 'dockerregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USER')]) {
-            sh "ping -c 3 dockerregistry.eigenbaumarkt.com"
             sh "./mvnw -ntp jib:build"        }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -57,7 +57,7 @@ node {
     def dockerImage
     withEnv(["DOCKER_CREDS=credentials('dockerregistry-login')"]) {
         stage('publish docker') {
-            sh "echo \"user=$DOCKER_CREDS_USR pass=$DOCKER_CREDS_PSW\"";
+            sh "echo \"user=${env.DOCKER_CREDS_USR}\"";
             sh "./mvnw -X -ntp jib:build"
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>""" jenkins.eigenbaumarkt.com:443/mesqualito/${project.name.toLowerCase()} """</image>
+                        <image>jenkins.eigenbaumarkt.com:443/mesqualito/${project.name.toLowerCase()}</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -475,7 +475,7 @@
                         </tags>
                         <auth>
                             <username>${env.DOCKER_REGISTRY_USR}</username>
-                            <password>${env.DOCKER_REGISTRY_PSW}</password>
+                            <password>${env.DOCKER_REGISTRY_PWD}</password>
                         </auth>
                     </to>
                     <container>

--- a/pom.xml
+++ b/pom.xml
@@ -471,7 +471,7 @@
                             <username>${env.DOCKER_REGISTRY_USER</username>
                             <password>${env.DOCKER_REGISTRY_PWD}</password>
                         </auth>
-                    <image>dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news</image>
+                    <image>dockerregistry.eigenbaumarkt.com:443/mesqualito/subjektiv-news</image>
                     <tags>
                         <tag>${maven.build.timestamp}</tag>
                         <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -468,8 +468,8 @@
                 <configuration>
                     <to>
                         <auth>
-                            <username>${env.DOCKER_REGISTRY_USER</username>
-                            <password>${env.DOCKER_REGISTRY_PWD}</password>
+                            <username>${DOCKER_REGISTRY_USER}</username>
+                            <password>${DOCKER_REGISTRY_PWD}</password>
                         </auth>
                     <image>dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news</image>
                     <tags>

--- a/pom.xml
+++ b/pom.xml
@@ -471,6 +471,11 @@
                             <username>${env.DOCKER_REGISTRY_USER</username>
                             <password>${env.DOCKER_REGISTRY_PWD}</password>
                         </auth>
+                    <image>dockerregistry.eigenbaumarkt.com:443/mesqualito/subjektiv-news</image>
+                    <tags>
+                        <tag>${maven.build.timestamp}</tag>
+                        <tag>latest</tag>
+                    </tags>
                     </to>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -467,6 +467,7 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
+                    <allowInsecureRegistries>true</allowInsecureRegistries>
                     <to>
                         <image>dockerregistry.eigenbaumarkt.com:5000/mesqualito/subjektiv-news</image>
                         <tags>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>jenkins.eigenbaumarkt.com:443/mesqualito/${project.name.toLowerCase()}</image>
+                        <image>jenkins.eigenbaumarkt.com:443/mesqualito/${StringUtils..toLowerCase("project.name")}</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -474,8 +474,8 @@
                             <tag>latest</tag>
                         </tags>
                         <auth>
-                            username "${System.env.DOCKER_CREDS_USR}"
-                            password "${System.env.DOCKER_CREDS_PSW}"
+                            <username>${System.env.DOCKER_CREDS_USR}</username>
+                            <password>${System.env.DOCKER_CREDS_PSW}</password>
                         </auth>
                     </to>
                     <container>

--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,9 @@
         <m2e.apt.activation>jdt_apt</m2e.apt.activation>
         <run.addResources>false</run.addResources>
         <!-- These remain empty unless the corresponding profile is active -->
-        <profile.no-liquibase />
-        <profile.swagger />
-        <profile.tls />
+        <profile.no-liquibase/>
+        <profile.swagger/>
+        <profile.tls/>
 
         <!-- Dependency versions -->
         <jhipster-dependencies.version>3.1.0</jhipster-dependencies.version>
@@ -465,6 +465,28 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
+                <configuration>
+                    <to>
+                        <image>${System.env.DOCKER_REGISTRY}/${project.name}</image>
+                        <tags>
+                            <tag>${maven.build.timestamp}</tag>
+                            <tag>latest</tag>
+                        </tags>
+                        <auth>
+                            username "${System.env.DOCKER_CREDS_USR}"
+                            password "${System.env.DOCKER_CREDS_PSW}"
+                        </auth>
+                    </to>
+                    <container>
+                        <jvmFlags>
+                            <jvmFlag>-Xms512m</jvmFlag>
+                            <jvmFlag>-Xmx1G</jvmFlag>
+                            <jvmFlag>-Xdebug</jvmFlag>
+                        </jvmFlags>
+                        <mainClass>de.subjektiv_news.SubjektivApp</mainClass>
+                    </container>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -605,7 +627,9 @@
                     <version>${liquibase.version}</version>
                     <configuration>
                         <changeLogFile>${project.basedir}/src/main/resources/config/liquibase/master.xml</changeLogFile>
-                        <diffChangeLogFile>${project.basedir}/src/main/resources/config/liquibase/changelog/${maven.build.timestamp}_changelog.xml</diffChangeLogFile>
+                        <diffChangeLogFile>
+                            ${project.basedir}/src/main/resources/config/liquibase/changelog/${maven.build.timestamp}_changelog.xml
+                        </diffChangeLogFile>
                         <driver>org.h2.Driver</driver>
                         <url>jdbc:h2:file:${project.build.directory}/h2db/db/subjektiv</url>
                         <defaultSchemaName></defaultSchemaName>
@@ -697,7 +721,7 @@
                             <id>enforce-dependencyConvergence</id>
                             <configuration>
                                 <rules>
-                                    <DependencyConvergence />
+                                    <DependencyConvergence/>
                                 </rules>
                                 <fail>false</fail>
                             </configuration>
@@ -709,11 +733,15 @@
                     <configuration>
                         <rules>
                             <requireMavenVersion>
-                                <message>You are running an older version of Maven. JHipster requires at least Maven ${maven.version}</message>
+                                <message>You are running an older version of Maven. JHipster requires at least Maven
+                                    ${maven.version}
+                                </message>
                                 <version>[${maven.version},)</version>
                             </requireMavenVersion>
                             <requireJavaVersion>
-                                <message>You are running an incompatible version of Java. JHipster supports JDK 8 to 13.</message>
+                                <message>You are running an incompatible version of Java. JHipster supports JDK 8 to
+                                    13.
+                                </message>
                                 <version>[1.8,14)</version>
                             </requireJavaVersion>
                         </rules>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>https://dockerregistry.eigenbaumarkt.com:443/mesqualito/subjektiv-news</image>
+                        <image>dockerregistry.eigenbaumarkt.com:443/mesqualito/subjektiv-news</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>jenkins.eigenbaumarkt.com:443/mesqualito/${project.name.toLowerCase()}</image>
+                        <image>""" jenkins.eigenbaumarkt.com:443/mesqualito/${project.name.toLowerCase()} """</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>dockerregistry.eigenbaumarkt.com:443/mesqualito/subjektiv-news</image>
+                        <image>dockerregistry.eigenbaumarkt.com:5000/mesqualito/subjektiv-news</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -474,8 +474,8 @@
                             <tag>latest</tag>
                         </tags>
                         <auth>
-                            <username>${env.DOCKER_CREDS_USR}</username>
-                            <password>${env.DOCKER_CREDS_PSW}</password>
+                            <username>${env.DOCKER_REGISTRY_USR}</username>
+                            <password>${env.DOCKER_REGISTRY_PSW}</password>
                         </auth>
                     </to>
                     <container>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>jenkins.eigenbaumarkt.com:443/Mesqualito/${project.name}:build-with-jib</image>
+                        <image>jenkins.eigenbaumarkt.com:443/mesqualito/${project.name.toLowerCase()}</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -467,9 +467,8 @@
                 <artifactId>jib-maven-plugin</artifactId>
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
-                    <allowInsecureRegistries>true</allowInsecureRegistries>
                     <to>
-                        <image>dockerregistry.eigenbaumarkt.com:5000/mesqualito/subjektiv-news</image>
+                        <image>dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>https://jenkins.eigenbaumarkt.com/${project.name}</image>
+                        <image>jenkins.eigenbaumarkt.com/${project.name}</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -465,28 +465,6 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
-                <configuration>
-                    <to>
-                        <auth>
-                            <username>${env.DOCKER_REGISTRY_USER}</username>
-                            <password>${env.DOCKER_REGISTRY_PWD}</password>
-                        </auth>
-                        <image>dockerregistry.eigenbaumarkt.com:443/mesqualito/subjektiv-news</image>
-                        <tags>
-                            <tag>${maven.build.timestamp}</tag>
-                            <tag>latest</tag>
-                        </tags>
-                    </to>
-                    <container>
-                        <jvmFlags>
-                            <jvmFlag>-Xms512m</jvmFlag>
-                            <jvmFlag>-Xmx1G</jvmFlag>
-                            <jvmFlag>-Xdebug</jvmFlag>
-                        </jvmFlags>
-                        <mainClass>de.subjektiv_news.SubjektivApp</mainClass>
-                    </container>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>jenkins.eigenbaumarkt.com:443/mesqualito/subjektiv-news</image>
+                        <image>dockerregistry.eigenbaumarkt.com:443/mesqualito/subjektiv-news</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>jenkins.eigenbaumarkt.com/${project.name}</image>
+                        <image>jenkins.eigenbaumarkt.com:443/Mesqualito/${project.name}</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>jenkins.eigenbaumarkt.com:443/mesqualito/${StringUtils..toLowerCase("project.name")}</image>
+                        <image>jenkins.eigenbaumarkt.com:443/mesqualito/${StringUtils.toLowerCase("project.name")}</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -471,12 +471,20 @@
                             <username>${env.DOCKER_REGISTRY_USER</username>
                             <password>${env.DOCKER_REGISTRY_PWD}</password>
                         </auth>
-                    <image>dockerregistry.eigenbaumarkt.com:443/mesqualito/subjektiv-news</image>
+                    <image>dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news</image>
                     <tags>
                         <tag>${maven.build.timestamp}</tag>
                         <tag>latest</tag>
                     </tags>
                     </to>
+                    <container>
+                        <jvmFlags>
+                            <jvmFlag>-Xms512m</jvmFlag>
+                            <jvmFlag>-Xmx1G</jvmFlag>
+                            <jvmFlag>-Xdebug</jvmFlag>
+                        </jvmFlags>
+                        <mainClass>de.subjektiv_news.SubjektivApp</mainClass>
+                    </container>
                 </configuration>
             </plugin>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,11 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>mesqualito/subjektiv-news</image>
+                        <auth>
+                            <username>${env.DOCKER_REGISTRY_USER}</username>
+                            <password>${env.DOCKER_REGISTRY_PWD}</password>
+                        </auth>
+                        <image>dockerregistry.eigenbaumarkt.com:443/mesqualito/subjektiv-news</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>jenkins.eigenbaumarkt.com:443/Mesqualito/${project.name}</image>
+                        <image>jenkins.eigenbaumarkt.com:443/Mesqualito/${project.name}:build-with-jib</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -465,6 +465,14 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
+                <configuration>
+                    <to>
+                        <auth>
+                            <username>${env.DOCKER_REGISTRY_USER</username>
+                            <password>${env.DOCKER_REGISTRY_PWD}</password>
+                        </auth>
+                    </to>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>${env.DOCKER_REGISTRY}/${project.name}</image>
+                        <image>https://jenkins.eigenbaumarkt.com/${project.name}</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -471,7 +471,7 @@
                             <username>${env.DOCKER_REGISTRY_USER</username>
                             <password>${env.DOCKER_REGISTRY_PWD}</password>
                         </auth>
-                    <image>213.133.103.43/mesqualito/subjektiv-news</image>
+                    <image>dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news</image>
                     <tags>
                         <tag>${maven.build.timestamp}</tag>
                         <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -468,14 +468,14 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>${System.env.DOCKER_REGISTRY}/${project.name}</image>
+                        <image>${env.DOCKER_REGISTRY}/${project.name}</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>
                         </tags>
                         <auth>
-                            <username>${System.env.DOCKER_CREDS_USR}</username>
-                            <password>${System.env.DOCKER_CREDS_PSW}</password>
+                            <username>${env.DOCKER_CREDS_USR}</username>
+                            <password>${env.DOCKER_CREDS_PSW}</password>
                         </auth>
                     </to>
                     <container>

--- a/pom.xml
+++ b/pom.xml
@@ -468,15 +468,11 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>dockerregistry.eigenbaumarkt.com:443/mesqualito/subjektiv-news</image>
+                        <image>mesqualito/subjektiv-news</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>
                         </tags>
-                        <auth>
-                            <username>${env.DOCKER_REGISTRY_USR}</username>
-                            <password>${env.DOCKER_REGISTRY_PWD}</password>
-                        </auth>
                     </to>
                     <container>
                         <jvmFlags>

--- a/pom.xml
+++ b/pom.xml
@@ -471,7 +471,7 @@
                             <username>${env.DOCKER_REGISTRY_USER</username>
                             <password>${env.DOCKER_REGISTRY_PWD}</password>
                         </auth>
-                    <image>dockerregistry.eigenbaumarkt.com:443/mesqualito/subjektiv-news</image>
+                    <image>213.133.103.43/mesqualito/subjektiv-news</image>
                     <tags>
                         <tag>${maven.build.timestamp}</tag>
                         <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>dockerregistry.eigenbaumarkt.com/mesqualito/subjektiv-news</image>
+                        <image>https://dockerregistry.eigenbaumarkt.com:443/mesqualito/subjektiv-news</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>

--- a/pom.xml
+++ b/pom.xml
@@ -468,7 +468,7 @@
                 <!-- adapted from: https://blog.ippon.tech/containerize-with-jib -->
                 <configuration>
                     <to>
-                        <image>jenkins.eigenbaumarkt.com:443/mesqualito/${StringUtils.toLowerCase("project.name")}</image>
+                        <image>jenkins.eigenbaumarkt.com:443/mesqualito/subjektiv-news</image>
                         <tags>
                             <tag>${maven.build.timestamp}</tag>
                             <tag>latest</tag>


### PR DESCRIPTION
0

Finally I've got it working.

In Jenkinsfile I edit the JHipster generated code to:

```
    def dockerImage
    stage('publish docker') {
        withCredentials([usernamePassword(credentialsId: 'myregistry-login', passwordVariable: 'DOCKER_REGISTRY_PWD', usernameVariable: 'DOCKER_REGISTRY_USER')]) {
            sh "./mvnw -ntp jib:build"        }
    }
```

In pom.xml I put the jib-maven-plugin configuration:

```
<plugin>
  <groupId>com.google.cloud.tools</groupId>
  <artifactId>jib-maven-plugin</artifactId>
  <configuration>
    <to>
      <auth>
        <username>${DOCKER_REGISTRY_USER}</username>
         <password>${DOCKER_REGISTRY_PWD}</password>
       </auth>
       <image>myregistry.mydomain.com/myuser/my_image</image>
       <tags>
         <tag>${maven.build.timestamp}</tag>
         <tag>latest</tag>
       </tags>
     </to>
   <container>
     <jvmFlags>
       <jvmFlag>-Xms512m</jvmFlag>
       <jvmFlag>-Xmx1G</jvmFlag>
       <jvmFlag>-Xdebug</jvmFlag>
     </jvmFlags>
     <mainClass>com.mypackage.MyApp</mainClass>
   </container>
  </configuration>
</plugin>
```

In my remote server setup my own docker registry v2 is running as a docker-container published via nginx-proxy with letsencrypt-nginx-proxy-companion. On the same custom network bridge runs my own jenkins server as another docker-container.

Some tests showed me that the container-name of the docker registry can not be named with the public DNS name of the registry (e.g. 'myregistry.mydomain.com' as container name). The jenkins docker-container gets the embedded docker dns server into resolv.conf, and docker will resolve the container-names of containers in the same network to the internal bridge-network IPs of these containers (only in case of custom docker networks).

I guess jib has to connect via ssl to push the docker image to the docker registry container and ssl has to be handled before the container with nginx-proxy, so the external address of the docker registry domain has to be used.

Also the docker hosts firewall has to be configured (according to this link) to allow traffic from the docker container jenkins through to the docker host. At the host it then goes back again to docker registry via nginx-proxy with ssl, right? In my case, this comes down to:

```
$ sudo firewall-cmd --info-zone=public
public (active)
  target: default
  icmp-block-inversion: no
  interfaces: enp6s0
  sources: 
  [...] 
  rich rules: 
    rule family="ipv4" source address="172.26.0.13/32" accept
```

